### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ Setting Unifi controller and Pihole on a docker container on Raspberry PI. I hav
 
     Unifi:
     ``` 
-    http://<PRIVATE_IP_ADDRESS_HERE>:8443
+    https://<PRIVATE_IP_ADDRESS_HERE>:8443
     ``` 


### PR DESCRIPTION
Use HTTPS url for Unifi controller (even though the browser will report URL is not secure)